### PR TITLE
also ban utcfromtimestamp

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -10,11 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9, "3.10"]
+        python-version: [3.8, 3.9, "3.10", 3.11]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: install tox

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,7 +40,7 @@ repos:
     rev: v3.3.1
     hooks:
     -   id: pyupgrade
-        args: [--py38-plus]
+        args: [--py39-plus]
 -   repo: https://github.com/asottile/setup-cfg-fmt
     rev: v2.2.0
     hooks:

--- a/README.md
+++ b/README.md
@@ -3,15 +3,27 @@
 
 # flake8-ban-utcnow
 
-flake8 plugin which checks that `datetime.utcnow()` is not used. It suggests using `datetime.now(timezone.utc)` instead.
+flake8 plugin which checks that `datetime.utcnow()` and `datetime.utcfromtimestamp()` are not used. It suggests using `datetime.now(timezone.utc)` and `datetime.fromtimestamp(ts, tz=timezone.utc)`instead respectively.
 
-**note:** timezone must be imported from datetime first:
+Also, `utcnow` and `utcfromtimestamp` are finally deprecated in Python 3.12:
+
+- PR: https://github.com/python/cpython/pull/103858
+- Issue: https://github.com/python/cpython/issues/103857
+
+**note:** timezone must be imported from `datetime` first:
 
 ```python
 from datetime import datetime
 from datetime import timezone
 
 datetime.now(timezone.utc)
+```
+
+```python
+from datetime import datetime
+from datetime import timezone
+
+datetime.fromtimestamp(1684079261, tz=timezone.utc)
 ```
 
 ## installation
@@ -22,9 +34,10 @@ pip install flake8-ban-utcnow
 
 ## flake8 code
 
-| Code   | Description                                                             |
-| ------ | ----------------------------------------------------------------------- |
-| UTC001 | don't use `datetime.utcnow()`, use `datetime.now(timezone.utc)` instead |
+| Code   | Description                                                                                                                                                                                     |
+| ------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| UTC001 | don't use datetime.datetime.utcnow(), use datetime.datetime.now(datetime.timezone.utc) instead or datetime.now(datetime.UTC) on >= 3.11.                                                        |
+| UTC002 | don't use datetime.datetime.utcfromtimestamp(), use datetime.datetime.fromtimestamp(..., tz=datetime.timezone.utc) instead or datetime.datetime.fromtimestamp(..., tz=datetime.UTC) on >= 3.11. |
 
 ## as a pre-commit hook
 
@@ -34,7 +47,7 @@ Sample `.pre-commit-config.yaml`:
 
 ```yaml
 - repo: https://github.com/pycqa/flake8
-  rev: 5.0.4
+  rev: 6.0.0
   hooks:
     - id: flake8
       additional_dependencies: [flake8-ban-utcnow==0.1.0]
@@ -88,7 +101,7 @@ timestamp from the `datetime` object created using `datetime.utcnow()`.
 ### the correct way
 
 - the computer is in `CEST` and we want to actually derive a `datetime` in **UTC**
-  formatted as a timestamp .
+  formatted as a timestamp.
 
   ```pycon
   >>> from datetime import timezone
@@ -105,6 +118,6 @@ timestamp from the `datetime` object created using `datetime.utcnow()`.
   Relative: A few seconds ago
   ```
 
-- the next thing to keep in mind is, that only timezone aware `datetime` objects
+- the next thing to keep in mind is, that only timezone-aware `datetime` objects
   can be compared hence using this forces us to always make sure all objects are
   timezone aware.

--- a/flake8_ban_utcnow.py
+++ b/flake8_ban_utcnow.py
@@ -1,37 +1,64 @@
-import ast
-from typing import Any
-from typing import Generator
-from typing import List
-from typing import Tuple
-from typing import Type
+from __future__ import annotations
 
-MSG = "UTC001 don't use datetime.datetime.utcnow(), use datetime.datetime.now(datetime.timezone.utc) instead or datetime.now(datetime.UTC) on >= 3.11."  # noqa: E501
+import ast
+from collections.abc import Generator
+from typing import Any
+from typing import Literal
+from typing import TypedDict
+
+
+class Messages(TypedDict):
+    utcnow: str
+    utcfromtimestamp: str
+
+
+MSG: Messages = {
+    'utcnow': "UTC001 don't use datetime.datetime.utcnow(), use datetime.datetime.now(datetime.timezone.utc) instead or datetime.now(datetime.UTC) on >= 3.11.",  # noqa: E501,
+    'utcfromtimestamp': "UTC002 don't use datetime.datetime.utcfromtimestamp(), use datetime.datetime.fromtimestamp(..., tz=datetime.timezone.utc) instead or datetime.datetime.fromtimestamp(..., tz=datetime.UTC) on >= 3.11.",  # noqa: E501
+}
+
+
+def _check_attr(
+        node: ast.Attribute,
+        attr: Literal['utcnow', 'utcfromtimestamp'],
+) -> tuple[int, int, str] | None:
+    if (
+        (
+            isinstance(node.value, ast.Attribute) and
+            node.attr == attr and
+            node.value.attr == 'datetime'
+        ) or (
+            isinstance(node.value, ast.Name) and
+            node.attr == attr and
+            node.value.id == 'datetime'
+        )
+    ):
+        return (node.lineno, node.col_offset, MSG[attr])
+    else:
+        return None
 
 
 class Visitor(ast.NodeVisitor):
     def __init__(self) -> None:
-        self.assignments: List[Tuple[int, int]] = []
+        self.assignments: list[tuple[int, int, str]] = []
 
     def visit_Call(self, node: ast.Call) -> None:
-        if isinstance(node.func, ast.Name) and node.func.id == 'utcnow':
-            self.assignments.append((node.lineno, node.col_offset))
-
+        if isinstance(node.func, ast.Name):
+            if node.func.id == 'utcnow':
+                self.assignments.append(
+                    (node.lineno, node.col_offset, MSG['utcnow']),
+                )
+            elif node.func.id == 'utcfromtimestamp':  # pragma: no branch
+                self.assignments.append(
+                    (node.lineno, node.col_offset, MSG['utcfromtimestamp']),
+                )
         self.generic_visit(node)
 
     def visit_Attribute(self, node: ast.Attribute) -> None:
-        if (
-            (
-                isinstance(node.value, ast.Attribute) and
-                node.attr == 'utcnow' and
-                node.value.attr == 'datetime'
-            ) or (
-                isinstance(node.value, ast.Name) and
-                node.attr == 'utcnow' and
-                node.value.id == 'datetime'
-            )
-        ):
-            self.assignments.append((node.lineno, node.col_offset))
-
+        if msg := _check_attr(node=node, attr='utcnow'):
+            self.assignments.append(msg)
+        elif msg := _check_attr(node=node, attr='utcfromtimestamp'):
+            self.assignments.append(msg)
         self.generic_visit(node)
 
 
@@ -39,8 +66,8 @@ class Plugin:
     def __init__(self, tree: ast.AST):
         self._tree = tree
 
-    def run(self) -> Generator[Tuple[int, int, str, Type[Any]], None, None]:
+    def run(self) -> Generator[tuple[int, int, str, type[Any]], None, None]:
         visitor = Visitor()
         visitor.visit(self._tree)
-        for line, col in visitor.assignments:
-            yield line, col, MSG, type(self)
+        for line, col, msg in visitor.assignments:
+            yield line, col, msg, type(self)

--- a/flake8_ban_utcnow.py
+++ b/flake8_ban_utcnow.py
@@ -5,7 +5,7 @@ from typing import List
 from typing import Tuple
 from typing import Type
 
-MSG = "UTC001 don't use datetime.utcnow(), use datetime.now(timezone.utc) instead"  # noqa: E501
+MSG = "UTC001 don't use datetime.datetime.utcnow(), use datetime.datetime.now(datetime.timezone.utc) instead or datetime.now(datetime.UTC) on >= 3.11."  # noqa: E501
 
 
 class Visitor(ast.NodeVisitor):

--- a/tests/flake8_ban_utcnow_test.py
+++ b/tests/flake8_ban_utcnow_test.py
@@ -4,7 +4,7 @@ import pytest
 
 from flake8_ban_utcnow import Plugin
 
-MSG = "UTC001 don't use datetime.utcnow(), use datetime.now(timezone.utc) instead"  # noqa: E501
+MSG = "UTC001 don't use datetime.datetime.utcnow(), use datetime.datetime.now(datetime.timezone.utc) instead or datetime.now(datetime.UTC) on >= 3.11."  # noqa: E501
 
 
 def results(s):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38, py39, py310, pre-commit
+envlist = py38, py39, py310, py311, pre-commit
 
 [testenv]
 deps = -rrequirements-dev.txt


### PR DESCRIPTION
`utcfromtimestamp` and `utcnow` will be deprecated in python 3.12